### PR TITLE
Add leaderboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # SpeedMiner
+
+Simple Minecraft minigame plugin example.
+
+Features:
+* SQLite persistence of player points
+* Sidebar scoreboard showing time left and points
+* `/speedminer top` command to view the best players
+* Players teleport to a random arena defined in `config.yml`
+* Supports multiple arenas for variety

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>SpeedMiner</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.0-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/speedminer/SpeedMiner.java
+++ b/src/main/java/com/example/speedminer/SpeedMiner.java
@@ -1,0 +1,44 @@
+package com.example.speedminer;
+
+import com.example.speedminer.database.DatabaseManager;
+import com.example.speedminer.game.GameManager;
+import com.example.speedminer.game.ArenaManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class SpeedMiner extends JavaPlugin {
+
+    private GameManager gameManager;
+    private DatabaseManager databaseManager;
+    private ArenaManager arenaManager;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        databaseManager = new DatabaseManager(this);
+        arenaManager = new ArenaManager(this);
+        gameManager = new GameManager(this, arenaManager);
+
+        if (getCommand("speedminer") != null) {
+            getCommand("speedminer").setExecutor(gameManager);
+        }
+        getServer().getPluginManager().registerEvents(gameManager, this);
+    }
+
+    @Override
+    public void onDisable() {
+        if (gameManager != null) {
+            gameManager.shutdown();
+        }
+        if (databaseManager != null) {
+            databaseManager.close();
+        }
+    }
+
+    public DatabaseManager getDatabaseManager() {
+        return databaseManager;
+    }
+
+    public ArenaManager getArenaManager() {
+        return arenaManager;
+    }
+}

--- a/src/main/java/com/example/speedminer/database/DatabaseManager.java
+++ b/src/main/java/com/example/speedminer/database/DatabaseManager.java
@@ -1,0 +1,96 @@
+package com.example.speedminer.database;
+
+import com.example.speedminer.SpeedMiner;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class DatabaseManager {
+    private final SpeedMiner plugin;
+    private Connection connection;
+
+    public record PlayerStat(String name, int points) {}
+
+    public DatabaseManager(SpeedMiner plugin) {
+        this.plugin = plugin;
+        setup();
+    }
+
+    private void setup() {
+        try {
+            String url = plugin.getConfig().getString("database.url", "jdbc:sqlite:plugins/SpeedMiner/speedminer.db");
+            String user = plugin.getConfig().getString("database.user", "");
+            String pass = plugin.getConfig().getString("database.password", "");
+            connection = DriverManager.getConnection(url, user, pass);
+            try (Statement stmt = connection.createStatement()) {
+                stmt.executeUpdate("CREATE TABLE IF NOT EXISTS speedminer_stats (" +
+                        "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                        "uuid TEXT NOT NULL," +
+                        "name TEXT NOT NULL," +
+                        "points INTEGER NOT NULL," +
+                        "last_played TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+                );
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void saveStats(UUID uuid, String name, int points) {
+        if (connection == null) return;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "INSERT INTO speedminer_stats(uuid, name, points) VALUES(?,?,?)")) {
+            ps.setString(1, uuid.toString());
+            ps.setString(2, name);
+            ps.setInt(3, points);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public int loadStats(String name) {
+        if (connection == null) return 0;
+        try (PreparedStatement ps = connection.prepareStatement(
+                "SELECT SUM(points) FROM speedminer_stats WHERE name=?")) {
+            ps.setString(1, name);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public List<PlayerStat> getTopPlayers(int limit) {
+        List<PlayerStat> list = new ArrayList<>();
+        if (connection == null) return list;
+        String sql = "SELECT name, SUM(points) as total FROM speedminer_stats GROUP BY name ORDER BY total DESC LIMIT ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, limit);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(new PlayerStat(rs.getString("name"), rs.getInt("total")));
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+    public void close() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/speedminer/game/ArenaManager.java
+++ b/src/main/java/com/example/speedminer/game/ArenaManager.java
@@ -1,0 +1,66 @@
+package com.example.speedminer.game;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class ArenaManager {
+
+    public record Arena(String world, double x, double y, double z, float yaw, float pitch) {
+        public Location toLocation() {
+            if (world == null) return null;
+            var w = Bukkit.getWorld(world);
+            if (w == null) return null;
+            return new Location(w, x, y, z, yaw, pitch);
+        }
+    }
+
+    private final List<Arena> arenas = new ArrayList<>();
+    private final Random random = new Random();
+
+    public ArenaManager(JavaPlugin plugin) {
+        var config = plugin.getConfig();
+        ConfigurationSection list = config.getConfigurationSection("arenas");
+        if (list != null) {
+            for (String key : list.getKeys(false)) {
+                ConfigurationSection sec = list.getConfigurationSection(key);
+                if (sec != null) {
+                    arenas.add(new Arena(
+                            sec.getString("world", "world"),
+                            sec.getDouble("x", 0.0),
+                            sec.getDouble("y", 64.0),
+                            sec.getDouble("z", 0.0),
+                            (float) sec.getDouble("yaw", 0.0),
+                            (float) sec.getDouble("pitch", 0.0)
+                    ));
+                }
+            }
+        }
+        if (arenas.isEmpty()) {
+            // fallback to single arena config
+            arenas.add(new Arena(
+                    config.getString("arena.world", "world"),
+                    config.getDouble("arena.x", 0.0),
+                    config.getDouble("arena.y", 64.0),
+                    config.getDouble("arena.z", 0.0),
+                    (float) config.getDouble("arena.yaw", 0.0),
+                    (float) config.getDouble("arena.pitch", 0.0)
+            ));
+        }
+    }
+
+    public List<Arena> getArenas() {
+        return Collections.unmodifiableList(arenas);
+    }
+
+    public Arena getRandomArena() {
+        if (arenas.isEmpty()) return null;
+        return arenas.get(random.nextInt(arenas.size()));
+    }
+}

--- a/src/main/java/com/example/speedminer/game/GameManager.java
+++ b/src/main/java/com/example/speedminer/game/GameManager.java
@@ -1,0 +1,193 @@
+package com.example.speedminer.game;
+
+import com.example.speedminer.SpeedMiner;
+import com.example.speedminer.database.DatabaseManager;
+import com.example.speedminer.game.ArenaManager;
+import com.example.speedminer.game.ArenaManager.Arena;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.*;
+
+public class GameManager implements CommandExecutor, Listener {
+
+    private final SpeedMiner plugin;
+    private final PointsManager pointsManager;
+    private final Set<UUID> participants = new HashSet<>();
+    private final ScoreboardManager scoreboardManager;
+    private final ArenaManager arenaManager;
+    private BukkitRunnable gameTask;
+
+    public GameManager(SpeedMiner plugin, ArenaManager arenaManager) {
+        this.plugin = plugin;
+        this.pointsManager = new PointsManager();
+        this.scoreboardManager = new ScoreboardManager(plugin);
+        this.arenaManager = arenaManager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.RED + "Usage: /speedminer <start|stop|stats>");
+            return true;
+        }
+        switch (args[0].toLowerCase()) {
+            case "start":
+                startGame(sender);
+                break;
+            case "stop":
+                stopGame(sender);
+                break;
+            case "stats":
+                if (args.length >= 2) {
+                    showStats(sender, args[1]);
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Usage: /speedminer stats <player>");
+                }
+                break;
+            case "top":
+                showTop(sender);
+                break;
+            default:
+                sender.sendMessage(ChatColor.RED + "Unknown subcommand");
+                break;
+        }
+        return true;
+    }
+
+    private void startGame(CommandSender sender) {
+        if (gameTask != null) {
+            sender.sendMessage(ChatColor.RED + "Game already running!");
+            return;
+        }
+        participants.clear();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            participants.add(player.getUniqueId());
+        }
+        pointsManager.clear();
+        int countdown = plugin.getConfig().getInt("game.countdown", 5);
+        Bukkit.broadcastMessage(ChatColor.GREEN + "SpeedMiner starting in " + countdown + " seconds!");
+        new BukkitRunnable() {
+            int time = countdown;
+            @Override
+            public void run() {
+                if (time <= 0) {
+                    cancel();
+                    beginGame();
+                    return;
+                }
+                Bukkit.broadcastMessage(ChatColor.YELLOW + "Starting in " + time + "...");
+                time--;
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    private void beginGame() {
+        teleportParticipants();
+        int duration = plugin.getConfig().getInt("game.duration", 180);
+        Bukkit.broadcastMessage(ChatColor.GREEN + "Go mine those ores!");
+        scoreboardManager.start(participants, duration);
+        gameTask = new BukkitRunnable() {
+            int time = duration;
+            @Override
+            public void run() {
+                if (time <= 0) {
+                    endGame();
+                    return;
+                }
+                time--;
+            }
+        };
+        gameTask.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    private void stopGame(CommandSender sender) {
+        if (gameTask == null) {
+            sender.sendMessage(ChatColor.RED + "Game is not running!");
+            return;
+        }
+        endGame();
+        sender.sendMessage(ChatColor.GREEN + "Game stopped.");
+    }
+
+    private void endGame() {
+        if (gameTask != null) {
+            gameTask.cancel();
+            gameTask = null;
+        }
+        scoreboardManager.stop();
+        Bukkit.broadcastMessage(ChatColor.GOLD + "SpeedMiner finished!");
+        List<Map.Entry<UUID, Integer>> sorted = new ArrayList<>(pointsManager.getAll().entrySet());
+        sorted.sort((a, b) -> Integer.compare(b.getValue(), a.getValue()));
+
+        DatabaseManager db = plugin.getDatabaseManager();
+        for (int i = 0; i < sorted.size(); i++) {
+            UUID uuid = sorted.get(i).getKey();
+            int points = sorted.get(i).getValue();
+            String name = Bukkit.getOfflinePlayer(uuid).getName();
+            Bukkit.broadcastMessage(ChatColor.AQUA + (i + 1) + ". " + name + " - " + points + " points");
+            db.saveStats(uuid, name, points);
+        }
+    }
+
+    private void showStats(CommandSender sender, String target) {
+        DatabaseManager db = plugin.getDatabaseManager();
+        int points = db.loadStats(target);
+        sender.sendMessage(ChatColor.AQUA + target + " has " + points + " total points.");
+    }
+
+    private void showTop(CommandSender sender) {
+        DatabaseManager db = plugin.getDatabaseManager();
+        List<DatabaseManager.PlayerStat> top = db.getTopPlayers(5);
+        sender.sendMessage(ChatColor.GOLD + "--- Top Players ---");
+        int rank = 1;
+        for (DatabaseManager.PlayerStat stat : top) {
+            sender.sendMessage(ChatColor.YELLOW + "" + rank + ". " + stat.name() + " - " + stat.points() + " points");
+            rank++;
+        }
+    }
+
+    private void teleportParticipants() {
+        Arena arena = arenaManager.getRandomArena();
+        if (arena == null) return;
+        Location loc = arena.toLocation();
+        if (loc == null) return;
+        for (UUID uuid : participants) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null) {
+                player.teleport(loc);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (gameTask == null) return;
+        UUID uuid = event.getPlayer().getUniqueId();
+        if (!participants.contains(uuid)) return;
+
+        String blockName = event.getBlock().getType().name();
+        int value = plugin.getConfig().getInt("points." + blockName, 0);
+        if (value > 0) {
+            event.setDropItems(false);
+            pointsManager.addPoints(uuid, value);
+            scoreboardManager.updatePoints(uuid, pointsManager.getPoints(uuid));
+        }
+    }
+
+    public void shutdown() {
+        if (gameTask != null) {
+            gameTask.cancel();
+        }
+        scoreboardManager.stop();
+    }
+}

--- a/src/main/java/com/example/speedminer/game/PointsManager.java
+++ b/src/main/java/com/example/speedminer/game/PointsManager.java
@@ -1,0 +1,26 @@
+package com.example.speedminer.game;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PointsManager {
+    private final Map<UUID, Integer> points = new HashMap<>();
+
+    public void addPoints(UUID uuid, int amount) {
+        points.merge(uuid, amount, Integer::sum);
+    }
+
+    public int getPoints(UUID uuid) {
+        return points.getOrDefault(uuid, 0);
+    }
+
+    public Map<UUID, Integer> getAll() {
+        return Collections.unmodifiableMap(points);
+    }
+
+    public void clear() {
+        points.clear();
+    }
+}

--- a/src/main/java/com/example/speedminer/game/ScoreboardManager.java
+++ b/src/main/java/com/example/speedminer/game/ScoreboardManager.java
@@ -1,0 +1,84 @@
+package com.example.speedminer.game;
+
+import com.example.speedminer.SpeedMiner;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ScoreboardManager {
+
+    private final SpeedMiner plugin;
+    private final Map<UUID, Scoreboard> boards = new HashMap<>();
+    private BukkitRunnable task;
+    private int timeLeft;
+
+    public ScoreboardManager(SpeedMiner plugin) {
+        this.plugin = plugin;
+    }
+
+    public void start(Collection<UUID> players, int duration) {
+        this.timeLeft = duration;
+        org.bukkit.scoreboard.ScoreboardManager manager = Bukkit.getScoreboardManager();
+        if (manager == null) return;
+        for (UUID uuid : players) {
+            Player player = Bukkit.getPlayer(uuid);
+            if (player == null) continue;
+            Scoreboard board = manager.getNewScoreboard();
+            Objective obj = board.registerNewObjective("speedminer", "dummy", ChatColor.GREEN + "SpeedMiner");
+            obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+            obj.getScore(ChatColor.AQUA + "Points").setScore(0);
+            obj.getScore(ChatColor.YELLOW + "Time Left").setScore(duration);
+            player.setScoreboard(board);
+            boards.put(uuid, board);
+        }
+        task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (timeLeft < 0) {
+                    cancel();
+                    return;
+                }
+                for (Scoreboard board : boards.values()) {
+                    Objective obj = board.getObjective("speedminer");
+                    if (obj != null) {
+                        obj.getScore(ChatColor.YELLOW + "Time Left").setScore(timeLeft);
+                    }
+                }
+                timeLeft--;
+            }
+        };
+        task.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    public void updatePoints(UUID uuid, int points) {
+        Scoreboard board = boards.get(uuid);
+        if (board == null) return;
+        Objective obj = board.getObjective("speedminer");
+        if (obj != null) {
+            obj.getScore(ChatColor.AQUA + "Points").setScore(points);
+        }
+    }
+
+    public void stop() {
+        if (task != null) {
+            task.cancel();
+            task = null;
+        }
+        for (UUID uuid : boards.keySet()) {
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null && Bukkit.getScoreboardManager() != null) {
+                p.setScoreboard(Bukkit.getScoreboardManager().getMainScoreboard());
+            }
+        }
+        boards.clear();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,19 @@
+game:
+  duration: 180
+  countdown: 5
+points:
+  DIAMOND_ORE: 10
+  EMERALD_ORE: 8
+  GOLD_ORE: 6
+  IRON_ORE: 4
+  COAL_ORE: 2
+  REDSTONE_ORE: 3
+  LAPIS_ORE: 3
+arenas:
+  default:
+    world: world
+    x: 0.0
+    y: 64.0
+    z: 0.0
+    yaw: 0.0
+    pitch: 0.0

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: SpeedMiner
+version: 1.0-SNAPSHOT
+main: com.example.speedminer.SpeedMiner
+api-version: '1.21'
+commands:
+  speedminer:
+    description: Manage SpeedMiner game
+    usage: /speedminer <start|stop|stats|top>


### PR DESCRIPTION
## Summary
- show top players stored in SQLite
- document scoreboard and leaderboard in README
- players teleport to configured arena before mining begins
- support multiple arenas and random teleport

## Testing
- `mvn -q package` *(fails: command not found)*
- `gradle build` *(fails: no Gradle build files)*

------
https://chatgpt.com/codex/tasks/task_e_687303913258832eb6362fcc601601b6