### PR TITLE
Fix SQL statement in DatabaseManager

### DIFF
--- a/src/main/java/com/example/speedminer/database/DatabaseManager.java
+++ b/src/main/java/com/example/speedminer/database/DatabaseManager.java
@@ -25,13 +25,13 @@ public class DatabaseManager {
             String pass = plugin.getConfig().getString("database.password", "");
             connection = DriverManager.getConnection(url, user, pass);
             try (Statement stmt = connection.createStatement()) {
-                stmt.executeUpdate("CREATE TABLE IF NOT EXISTS speedminer_stats (" +
+                stmt.executeUpdate(
+                        "CREATE TABLE IF NOT EXISTS speedminer_stats(" +
                         "id INTEGER PRIMARY KEY AUTOINCREMENT," +
                         "uuid TEXT NOT NULL," +
                         "name TEXT NOT NULL," +
                         "points INTEGER NOT NULL," +
-                        "last_played TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
-                );
+                        "last_played TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
             }
         } catch (SQLException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Summary
- correct the SQL create table command to avoid extra `)` that caused compilation failure

## Testing
- `javac @sources.txt` *(fails: cannot find symbols for Bukkit API)*

------
https://chatgpt.com/codex/tasks/task_e_68730ac814cc832e818cd62dee5c54b6