### PR TITLE
Fix SQLite table creation

### DIFF
--- a/src/main/java/com/example/speedminer/database/DatabaseManager.java
+++ b/src/main/java/com/example/speedminer/database/DatabaseManager.java
@@ -31,7 +31,7 @@ public class DatabaseManager {
                         "uuid TEXT NOT NULL," +
                         "name TEXT NOT NULL," +
                         "points INTEGER NOT NULL," +
-                        "last_played TIMESTAMP DEFAULT CURRENT_TIMESTAMP");
+                        "last_played TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
             }
         } catch (SQLException e) {
             e.printStackTrace();


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in DatabaseManager

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687310a7e0b4832ea91b0ac9769df4d5